### PR TITLE
Example demo Docker demo broke with Alpine 3.8 upgrade.

### DIFF
--- a/example_setup/idp/Dockerfile
+++ b/example_setup/idp/Dockerfile
@@ -1,8 +1,8 @@
-FROM python:3.6-alpine
+FROM python:3.6.6-alpine3.7
 
 RUN apk add --update \
     build-base libffi-dev openssl-dev \
-    xmlsec \
+    xmlsec xmlsec-dev \
   && rm -rf /var/cache/apk/*
 
 ADD requirements.txt /tmp

--- a/example_setup/sp/Dockerfile
+++ b/example_setup/sp/Dockerfile
@@ -1,8 +1,8 @@
-FROM python:3.6-alpine
+FROM python:3.6.6-alpine3.7
 
 RUN apk add --update \
     build-base libffi-dev openssl-dev \
-    xmlsec \
+    xmlsec xmlsec-dev \
   && rm -rf /var/cache/apk/*
 
 ADD requirements.txt /tmp


### PR DESCRIPTION
Pinning the image python:3.6.6-alpine3.7 fixes the issue, and the demo works for both idp-initiated and sp-initiated.  Prior to the fix, attempting to login to the SP would produce an [error similar to the bug report 9110](https://bugs.alpinelinux.org/issues/9110) for Alpine Linux 3.8.

---
func=xmlSecCryptoDLLibraryCreate:file=dl.c:line=130:obj=unknown:subj=lt_dlopenext:error=7:io function failed:name="libxmlsec1-openssl"; errno=2 func=xmlSecCryptoDLGetLibraryFunctions:file=dl.c:line=436:obj=unknown:subj=xmlSecCryptoDLLibraryCreate:error=1:xmlsec library function failed:crypto=openssl func=xmlSecCryptoDLLoadLibrary:file=dl.c:line=393:obj=unknown:subj=xmlSecCryptoDLGetLibraryFunctions:error=1:xmlsec library function failed: Error: unable to load xmlsec-openssl library. Make sure that you have this it installed, check shared libraries path (LD_LIBRARY_PATH) envornment variable or use "--crypto" option to specify different crypto engine. Error: initialization failed func=xmlSecCryptoShutdown:file=app.c:line=65:obj=unknown:subj=unknown:error=9:feature is not implemented:details=cryptoShutdown Error: xmlSecCryptoShutdown failed Error: xmlsec crypto shutdown failed.
___

At first, I tried installing xmlsec-dev, but that did not clear up the issue. The LD_LIBRARY_PATH was empty, but I was not not sure what the path should be. After the downgrade to Alpine 3.7, this error went away and the LD_LIBRARY_PATH was still empty. 

To ensure a stable demo, it makes sense to pin the Docker image version to a known-working image.
