### PR TITLE
Added basic support for custom user model without 'username'

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -135,6 +135,10 @@ You also have to define a mapping for each SP you talk to::
         }
     }
 
+If you're using a custom user model that uses email instead of username to identify users (or anything else for that matter), you can use the following setting (defaults to username)::
+
+    SAML_IDP_IDENTIFYING_ATTRIBUTE = 'username'
+
 
 That's all for the IdP configuration. Assuming you run the Django development server on localhost:8000, you can get its metadata by visiting http://localhost:8000/idp/metadata/.
 Use this metadata xml to configure your SP. Place the metadata xml from that SP in the location specified in the config dict (sp_metadata.xml in the example above).

--- a/djangosaml2idp/urls.py
+++ b/djangosaml2idp/urls.py
@@ -5,8 +5,8 @@ from . import views
 app_name = 'djangosaml2idp'
 
 urlpatterns = [
-    path('sso/post', views.sso_entry, name="saml_login_post"),
-    path('sso/redirect', views.sso_entry, name="saml_login_redirect"),
+    path('sso/post', views.sso_post, name="saml_login_post"),
+    path('sso/redirect', views.sso_redirect, name="saml_login_redirect"),
     path('sso/init', views.SSOInitView.as_view(), name="saml_idp_init"),
     path('login/process/', views.LoginProcessView.as_view(), name='saml_login_process'),
     path('login/process_multi_factor/', views.ProcessMultiFactorView.as_view(), name='saml_multi_factor'),

--- a/djangosaml2idp/views.py
+++ b/djangosaml2idp/views.py
@@ -34,6 +34,8 @@ try:
 except AttributeError:
     raise ImproperlyConfigured("SAML_IDP_SPCONFIG not defined in settings.")
 
+user_identity = getattr(settings, 'SAML_IDP_IDENTIFYING_ATTRIBUTE', 'username')
+
 
 @never_cache
 @csrf_exempt
@@ -88,7 +90,7 @@ class IdPHandlerViewMixin:
     def get_identity(self, processor, user, sp_config):
         """ Create Identity dict (using SP-specific mapping)
         """
-        sp_mapping = sp_config.get('attribute_mapping', {'username': 'username'})
+        sp_mapping = sp_config.get('attribute_mapping', {user_identity: user_identity})
         return processor.create_identity(user, sp_mapping)
 
 
@@ -145,8 +147,8 @@ class LoginProcessView(LoginRequiredMixin, IdPHandlerViewMixin, View):
         # Construct SamlResponse message
         try:
             authn_resp = self.IDP.create_authn_response(
-                identity=identity, userid=request.user.username,
-                name_id=NameID(format=resp_args['name_id_policy'].format, sp_name_qualifier=resp_args['destination'], text=request.user.username),
+                identity=identity, userid=getattr(request.user, user_identity),
+                name_id=NameID(format=resp_args['name_id_policy'].format, sp_name_qualifier=resp_args['destination'], text=getattr(request.user, user_identity)),
                 authn=AUTHN_BROKER.get_authn_by_accr(req_authn_context),
                 sign_response=self.IDP.config.getattr("sign_response", "idp") or False,
                 sign_assertion=self.IDP.config.getattr("sign_assertion", "idp") or False,
@@ -216,7 +218,7 @@ class SSOInitView(LoginRequiredMixin, IdPHandlerViewMixin, View):
         # Construct SamlResponse messages
         try:
             name_id_formats = self.IDP.config.getattr("name_id_format", "idp") or [NAMEID_FORMAT_UNSPECIFIED]
-            name_id = NameID(format=name_id_formats[0], text=request.user.username)
+            name_id = NameID(format=name_id_formats[0], text=getattr(request.user, user_identity))
             authn = AUTHN_BROKER.get_authn_by_accr(req_authn_context)
             sign_response = self.IDP.config.getattr("sign_response", "idp") or False
             sign_assertion = self.IDP.config.getattr("sign_assertion", "idp") or False
@@ -225,7 +227,7 @@ class SSOInitView(LoginRequiredMixin, IdPHandlerViewMixin, View):
                 in_response_to="IdP_Initiated_Login",
                 destination=destination,
                 sp_entity_id=sp_entity_id,
-                userid=request.user.username,
+                userid=getattr(request.user, user_identity),
                 name_id=name_id,
                 authn=authn,
                 sign_response=sign_response,

--- a/djangosaml2idp/views.py
+++ b/djangosaml2idp/views.py
@@ -165,6 +165,8 @@ class LoginProcessView(LoginRequiredMixin, IdPHandlerViewMixin, View):
             sp_config = settings.SAML_IDP_SPCONFIG[resp_args['sp_entity_id']]
         except Exception:
             return self.handle_error(request, exception=ImproperlyConfigured("No config for SP %s defined in SAML_IDP_SPCONFIG" % resp_args['sp_entity_id']), status=400)
+        user_identity = getattr(
+            settings, 'SAML_IDP_IDENTIFYING_ATTRIBUTE', 'username')
         if sp_config.get('NameIDAttr', None):
             user_identity = sp_config.get('NameIDAttr')
 
@@ -253,6 +255,8 @@ class SSOInitView(LoginRequiredMixin, IdPHandlerViewMixin, View):
         except Exception:
             return self.handle_error(request, exception=ImproperlyConfigured("No config for SP %s defined in SAML_IDP_SPCONFIG" % sp_entity_id), status=400)
 
+        user_identity = getattr(
+            settings, 'SAML_IDP_IDENTIFYING_ATTRIBUTE', 'username')
         if sp_config.get('NameIDAttr', None):
             user_identity = sp_config.get('NameIDAttr')
 
@@ -302,7 +306,7 @@ class SSOInitView(LoginRequiredMixin, IdPHandlerViewMixin, View):
             binding=binding_out,
             msg_str="%s" % authn_resp,
             destination=destination,
-            relay_state=relayState,
+            relay_state=request.session['RelayState'],
             response=True)
         return HttpResponse(http_args['data'])
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -85,6 +85,10 @@ You also have to define a mapping for each SP you talk to::
         }
     }
 
+If you're using a custom user model that uses email instead of username to identify users (or anything else for that matter), you can use the following setting (defaults to username)::
+
+    SAML_IDP_IDENTIFYING_ATTRIBUTE = 'username'
+
 
 That's all for the IdP configuration. Assuming you run the Django development server on localhost:8000, you can get its metadata by visiting http://localhost:8000/idp/metadata/.
 Use this metadata xml to configure your SP. Place the metadata xml from that SP in the location specified in the config dict (sp_metadata.xml in the example above).


### PR DESCRIPTION
As of now, 'username' is hardcoded as the identifying attribute, meaning that any custom user model must have a username. This PR attempts to fix this by adding the option to choose which identifying attribute to use.