### PR TITLE
Bugfix get_nameid_unspecified and friends (refs #52)

### DIFF
--- a/djangosaml2idp/processors.py
+++ b/djangosaml2idp/processors.py
@@ -46,19 +46,19 @@ class NameIdBuilder:
         return '!'.join([idp_entityid, sp_entityid, cls._get_nameid_opaque(user_id, salt=str(user.pk).encode())])
 
     @classmethod
-    def get_nameid_email(cls, user_id):
+    def get_nameid_email(cls, user_id, **kwargs):
         if '@' not in user_id:
             raise Exception("user_id {} does not contain the '@' symbol, so is not a valid NameID Email address format.".format(user_id))
         return user_id
 
     @classmethod
-    def get_nameid_transient(cls, user_id):
+    def get_nameid_transient(cls, user_id, **kwargs):
         """ This would return EPPN
         """
         return user_id
 
     @classmethod
-    def get_nameid_unspecified(cls, user_id):
+    def get_nameid_unspecified(cls, user_id, **kwargs):
         """ returns user_id as is
         """
         return user_id


### PR DESCRIPTION
It looks like these methods are called with extra
arguments (e.g. sp_entityid), which are not used
in these specific methods.

Of course, Python complains if they are passed.
By allowing any kwargs, these are silently
ignored (as I believe they should, since they
are not relevant).

I only encountered the problem for 
get_nameid_unspecified, but I noticed some other
methods that might have the same problem so I
changed them as well.