### PR TITLE
Django3 compatibility

### DIFF
--- a/djangosaml2idp/views.py
+++ b/djangosaml2idp/views.py
@@ -305,6 +305,7 @@ class SSOInitView(LoginRequiredMixin, IdPHandlerViewMixin, View):
 
     def get(self, request, *args, **kwargs):
         passed_data = request.POST or request.GET
+        passed_data = passed_data.copy().dict()
 
         try:
             # get sp information from the parameters


### PR DESCRIPTION
I noticed that Django3 has an immutable QueryDict,
so if we try to update it, it will fail. Making a
copy and forcing it to be a dict will solved these
problems (tested with djangosaml2idp as IDP and
another djangosaml2idp as SP, both SP-initiated
as well as IDP-initiated logins).