### PR TITLE
restructure error handler logic

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -173,8 +173,7 @@ Customizing error handling
 ==========================
 
 djangosaml2idp renders a very basic error page if it encounters an error, indicating an error occured, which error, and possibly an extra message.
-It also logs the exception with error severity.
-The HTTP status code is also set if possible, depending on which error occured.
+The HTTP status code is dependant on which error occured. It also logs the exception with error severity.
 You can customize this by using the ``SAML_IDP_ERROR_VIEW_CLASS`` setting. Set this to a dotted import path to your custom (class based) view in order to use that one.
 You'll likely want this to use your own template and styling to display and error message.
 If you subclass the provided `djangosaml2idp.error_views.SamlIDPErrorView`, you have the following variables available for use in the template:

--- a/README.rst
+++ b/README.rst
@@ -173,9 +173,14 @@ Customizing error handling
 ==========================
 
 djangosaml2idp renders a very basic error page if it encounters an error, indicating an error occured, which error, and possibly an extra message.
-The HTTP status code is also set if possible depending on which error occured.
+It also logs the exception with error severity.
+The HTTP status code is also set if possible, depending on which error occured.
 You can customize this by using the ``SAML_IDP_ERROR_VIEW_CLASS`` setting. Set this to a dotted import path to your custom (class based) view in order to use that one.
+You'll likely want this to use your own template and styling to display and error message.
 If you subclass the provided `djangosaml2idp.error_views.SamlIDPErrorView`, you have the following variables available for use in the template:
+
+exception
+  the exception instance that occurred
 
 exception_type
   the class of the exception that occurred

--- a/djangosaml2idp/error_views.py
+++ b/djangosaml2idp/error_views.py
@@ -1,18 +1,43 @@
+import logging
+
+from django.conf import settings
+from django.http import HttpRequest, HttpResponse
+from django.utils.module_loading import import_string
 from django.views.generic import TemplateView
+
+logger = logging.getLogger(__name__)
 
 
 class SamlIDPErrorView(TemplateView):
-    """ Default error view when a 'known' error occurs in the saml2 authentication views.
+    """ Default error view used when a 'known' error occurs in the saml2 authentication views.
+        Subclass this to use your own template and styling for the error page (only set template_name on your subclass),
+        or to do entirely customized error handling (override the handle_error method).
+        settings.SAML_IDP_ERROR_VIEW_CLASS should point to your customized subclass.
     """
     template_name = 'djangosaml2idp/error.html'
 
-    def get_context_data(self, **kwargs):
+    @classmethod
+    def handle_error(cls, request: HttpRequest, exception: Exception, status_code: int = 500, **kwargs) -> HttpResponse:
+        """ Default behaviour: log the exception as error-level, and render an error page with the desired status_code on the response. """
+        logger.error(kwargs, exc_info=exception)
+
+        # Render an http response and return it
+        response = cls.as_view()(request, exception=exception, **kwargs)
+        response.status_code = status_code
+        return response
+
+    def get_context_data(self, **kwargs) -> dict:
+        """ Add some exception-related variables to the context for usage in the template. """
         context = super().get_context_data(**kwargs)
         exception = kwargs.get("exception")
 
         context.update({
+            "exception": exception,
             "exception_type": exception.__class__.__name__ if exception else None,
-            "exception_msg": str(exception) if exception else None,
+            "exception_msg": exception.message if exception else None,
             "extra_message": kwargs.get("extra_message"),
         })
         return context
+
+
+error_cbv = import_string(getattr(settings, 'SAML_IDP_ERROR_VIEW_CLASS', 'djangosaml2idp.error_views.SamlIDPErrorView'))

--- a/djangosaml2idp/templates/djangosaml2idp/error.html
+++ b/djangosaml2idp/templates/djangosaml2idp/error.html
@@ -3,12 +3,13 @@
 
 <head>
     <meta charset="utf-8">
-    <title>ERROR</title>
+    <title>SAML2 Error</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
 
 <body>
     <h2>Error during SAML2 authentication</h2>
+
     {% if exception_type %}
         <p><strong>{{exception_type}}</strong><br>
         {% if exception_msg %}

--- a/docs/error.rst
+++ b/docs/error.rst
@@ -2,9 +2,14 @@ Customizing error handling
 ==========================
 
 djangosaml2idp renders a very basic error page if it encounters an error, indicating an error occured, which error, and possibly an extra message.
-The HTTP status code is also set if possible depending on which error occured.
+It also logs the exception with error severity.
+The HTTP status code is also set if possible, depending on which error occured.
 You can customize this by using the ``SAML_IDP_ERROR_VIEW_CLASS`` setting. Set this to a dotted import path to your custom (class based) view in order to use that one.
+You'll likely want this to use your own template and styling to display and error message.
 If you subclass the provided `djangosaml2idp.error_views.SamlIDPErrorView`, you have the following variables available for use in the template:
+
+exception
+  the exception instance that occurred
 
 exception_type
   the class of the exception that occurred

--- a/docs/error.rst
+++ b/docs/error.rst
@@ -2,8 +2,7 @@ Customizing error handling
 ==========================
 
 djangosaml2idp renders a very basic error page if it encounters an error, indicating an error occured, which error, and possibly an extra message.
-It also logs the exception with error severity.
-The HTTP status code is also set if possible, depending on which error occured.
+The HTTP status code is dependant on which error occured. It also logs the exception with error severity.
 You can customize this by using the ``SAML_IDP_ERROR_VIEW_CLASS`` setting. Set this to a dotted import path to your custom (class based) view in order to use that one.
 You'll likely want this to use your own template and styling to display and error message.
 If you subclass the provided `djangosaml2idp.error_views.SamlIDPErrorView`, you have the following variables available for use in the template:


### PR DESCRIPTION
Closes https://github.com/OTA-Insight/djangosaml2idp/issues/58

Allows better error handling customization by end-users. All error handling can now be customized by defining one customized view in the settings. Previously this required to subclass multiple views in the saml2 flow.