### PR TITLE
Always all refresh_metadata on form submission

### DIFF
--- a/djangosaml2idp/forms.py
+++ b/djangosaml2idp/forms.py
@@ -53,9 +53,9 @@ class ServiceProviderAdminForm(forms.ModelForm):
             processor_cls = validate_processor_path(processor_path)
             instantiate_processor(processor_cls, entity_id)
 
+        self.instance.local_metadata = cleaned_data.get('local_metadata')
         # Call the validation methods to catch ValidationErrors here, so they get displayed cleanly in the admin UI
         if cleaned_data.get('remote_metadata_url'):
             self.instance.remote_metadata_url = cleaned_data.get('remote_metadata_url')
-            self.instance.local_metadata = cleaned_data.get('local_metadata')
-            self.instance.refresh_metadata(force_refresh=True)
             cleaned_data['local_metadata'] = self.instance.local_metadata
+        self.instance.refresh_metadata(force_refresh=True)

--- a/djangosaml2idp/models.py
+++ b/djangosaml2idp/models.py
@@ -48,7 +48,12 @@ class ServiceProvider(models.Model):
         '''
         if not self.local_metadata or not self.metadata_expiration_dt or now() > self.metadata_expiration_dt or force_refresh:
             if self.remote_metadata_url:
-                self.local_metadata = validate_metadata(fetch_metadata(self.remote_metadata_url))
+                try:
+                    self.local_metadata = validate_metadata(fetch_metadata(self.remote_metadata_url))
+                except Exception:
+                    logger.error(f'Metadata for SP {self.entity_id} could not be pulled from remote url {self.remote_metadata_url}.')
+            elif now() > self.metadata_expiration_dt:
+                logger.error(f'Metadata for SP {self.entity_id} has expired, no remote metadata found to refresh.')
             self.metadata_expiration_dt = extract_validuntil_from_metadata(self.local_metadata)
             return True
         return False


### PR DESCRIPTION
Right now, refresh_metadata is only called when remote_metadata_url is present. This means that expiration datetimes aren't parsed out of locally provided metadata. Additionally, error logging has been added if metadata has expired but there's no remote url, and if metadata can't be fetched from remote (included with this PR, on the last one I forgot to push that commit).