### PR TITLE
Fixed os.path.join in README example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -101,7 +101,7 @@ In your Django settings, configure your IdP. Configuration follows the `PySAML2 
         },
 
         'metadata': {
-            'local': [os.path.join(os.path.join(os.path.join(BASE_DIR, 'idp'), 'saml2_config'), 'sp_metadata.xml')],
+            'local': [os.path.join(BASE_DIR, 'idp', 'saml2_config', 'sp_metadata.xml')],
         },
         # Signing
         'key_file': BASE_DIR + '/certificates/private.key',


### PR DESCRIPTION
No need for multiple calls to `os.path.join`. You can pass multiple args to the function.