### PR TITLE
Improve metadata validation in admin form

### DIFF
--- a/djangosaml2idp/models.py
+++ b/djangosaml2idp/models.py
@@ -8,6 +8,7 @@ from typing import Dict
 import pytz
 from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils.functional import cached_property
 from django.utils.safestring import mark_safe
@@ -83,12 +84,10 @@ class ServiceProvider(models.Model):
             self.metadata_expiration_dt = extract_validuntil_from_metadata(self.local_metadata).replace(tzinfo=None)
             # Return True if it is now valid, False (+ log an error) otherwise
             if now() > self.metadata_expiration_dt:
-                logger.error(f'Remote metadata for SP {self.entity_id} was refreshed, but contains an expired validity datetime.')
-                return False
+                raise ValidationError(f'Remote metadata for SP {self.entity_id} was refreshed, but contains an expired validity datetime.')
             return True
         except Exception as e:
-            logger.error(f'Metadata for SP {self.entity_id} could not be pulled from remote url {self.remote_metadata_url}.', extra={'exception': str(e)})
-            return False
+            raise ValidationError(f'Metadata for SP {self.entity_id} could not be pulled from remote url {self.remote_metadata_url}.') from e
 
     def _refresh_from_local(self) -> bool:
         try:
@@ -96,13 +95,11 @@ class ServiceProvider(models.Model):
             self.metadata_expiration_dt = extract_validuntil_from_metadata(self.local_metadata).replace(tzinfo=None)
             # Return True if it is now valid, False (+ log an error) otherwise
             if now() > self.metadata_expiration_dt:
-                logger.error(f'Local metadata for SP {self.entity_id} contains an expired validity datetime or none at all, no remote metadata found to refresh.')
-                return False
+                raise ValidationError(f'Local metadata for SP {self.entity_id} contains an expired validity datetime or none at all, no remote metadata found to refresh.')
             return True
         except Exception as e:
             # Could not extract a valid expiry timestamp, return False (+ log an error)
-            logger.error(f'Metadata expiration dt for SP {self.entity_id} could not be extracted from local metadata.', extra={'exception': str(e)})
-            return False
+            raise ValidationError(f'Metadata expiration dt for SP {self.entity_id} could not be extracted from local metadata.') from e
 
     def refresh_metadata(self, force_refresh: bool = False) -> bool:
         ''' If a remote metadata url is set, fetch new metadata if the locally cached one is expired. Returns True if new metadata was set.
@@ -116,10 +113,18 @@ class ServiceProvider(models.Model):
             return False
 
         if self.remote_metadata_url:
-            return self._refresh_from_remote()
+            try:
+                return self._refresh_from_remote()
+            except ValidationError as e:
+                logger.error('Unable to refresh remote metadata', extra={'exception': str(e)})
+                return False
 
         if force_refresh or (not self.metadata_expiration_dt) or (now() > self.metadata_expiration_dt) or self.field_value_changed('local_metadata'):
-            return self._refresh_from_local()
+            try:
+                return self._refresh_from_local()
+            except ValidationError as e:
+                logger.error('Unable to refresh local metadata', extra={'exception': str(e)})
+                return False
 
         raise Exception('Uncaught case of refresh_metadata')
 


### PR DESCRIPTION
Allow ValidationError to bubble up.
Allow entering a remote url without local metadata.
Remove metadata_expiration_dt because it is always readonly.