### PR TITLE
Gracefully handle naive expirate date

### DIFF
--- a/djangosaml2idp/utils.py
+++ b/djangosaml2idp/utils.py
@@ -6,6 +6,7 @@ import xml.etree.ElementTree as ET
 import zlib
 from xml.parsers.expat import ExpatError
 from django.conf import settings
+from django.utils.timezone import is_naive, make_aware
 from django.utils.translation import gettext as _
 import arrow
 import requests
@@ -71,4 +72,6 @@ def extract_validuntil_from_metadata(metadata: str) -> datetime.datetime:
 
     if not settings.USE_TZ:
         return metadata_expiration_dt.replace(tzinfo=None)
+    if is_naive(metadata_expiration_dt):
+        return make_aware(metadata_expiration_dt)
     return metadata_expiration_dt


### PR DESCRIPTION
Otherwise it crashes with errors:
Metadata expiration dt for SP <nextcloud>/apps/user_saml/saml/metadata
could not be extracted from local metadata: can\'t compare offset-naive
and offset-aware datetimes