### PR TITLE
Use only the directory of the xmlsec binary in the example conf

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -85,7 +85,7 @@ In your Django settings, configure your IdP. Configuration follows the `PySAML2 
 
     SAML_IDP_CONFIG = {
         'debug' : DEBUG,
-        'xmlsec_binary': get_xmlsec_binary(['/opt/local/bin', '/usr/bin/xmlsec1']),
+        'xmlsec_binary': get_xmlsec_binary(['/opt/local/bin', '/usr/bin']),
         'entityid': '%s/metadata' % BASE_URL,
         'description': 'Example IdP setup',
 


### PR DESCRIPTION
The `get_xmlsec_binary` function will append the name of the binary when looking for it : https://github.com/IdentityPython/pysaml2/blob/6ca05dd8a95bf6bdb74dc742699f54febca23d05/src/saml2/sigver.py#L157-L192