### PR TITLE
Allow to customize the IDP views login redirect

### DIFF
--- a/djangosaml2idp/views.py
+++ b/djangosaml2idp/views.py
@@ -38,11 +38,11 @@ User = get_user_model()
 
 
 class CustomLoginRequiredMixin(LoginRequiredMixin):
-     def get_login_url(self):
-         if hasattr(settings, "SAML_IDP_LOGIN_URL"):
-             return str(settings.SAML_IDP_LOGIN_URL)
-         else:
-             return super().get_login_url()
+    def get_login_url(self):
+        if hasattr(settings, "SAML_IDP_LOGIN_URL"):
+            return str(settings.SAML_IDP_LOGIN_URL)
+        else:
+            return super().get_login_url()
 
 
 def store_params_in_session(request: HttpRequest) -> None:

--- a/djangosaml2idp/views.py
+++ b/djangosaml2idp/views.py
@@ -37,6 +37,14 @@ logger = logging.getLogger(__name__)
 User = get_user_model()
 
 
+class CustomLoginRequiredMixin(LoginRequiredMixin):
+     def get_login_url(self):
+         if hasattr(settings, "SAML_IDP_LOGIN_URL"):
+             return str(settings.SAML_IDP_LOGIN_URL)
+         else:
+             return super().get_login_url()
+
+
 def store_params_in_session(request: HttpRequest) -> None:
     """ Gathers the SAML parameters from the HTTP request and store them in the session
     """
@@ -219,7 +227,7 @@ class IdPHandlerViewMixin:
 
 
 @method_decorator(never_cache, name='dispatch')
-class LoginProcessView(LoginRequiredMixin, IdPHandlerViewMixin, View):
+class LoginProcessView(CustomLoginRequiredMixin, IdPHandlerViewMixin, View):
     """ View which processes the actual SAML request and returns a self-submitting form with the SAML response.
         The login_required decorator ensures the user authenticates first on the IdP using 'normal' ways.
     """
@@ -269,7 +277,7 @@ class LoginProcessView(LoginRequiredMixin, IdPHandlerViewMixin, View):
 
 
 @method_decorator(never_cache, name='dispatch')
-class SSOInitView(LoginRequiredMixin, IdPHandlerViewMixin, View):
+class SSOInitView(CustomLoginRequiredMixin, IdPHandlerViewMixin, View):
     """ View used for IDP initialized login, doesn't handle any SAML authn request
     """
 
@@ -312,7 +320,7 @@ class SSOInitView(LoginRequiredMixin, IdPHandlerViewMixin, View):
 
 
 @method_decorator(never_cache, name='dispatch')
-class ProcessMultiFactorView(LoginRequiredMixin, View):
+class ProcessMultiFactorView(CustomLoginRequiredMixin, View):
     """ This view is used in an optional step is to perform 'other' user validation, for example 2nd factor checks.
         Override this view per the documentation if using this functionality to plug in your custom validation logic.
     """
@@ -337,7 +345,7 @@ class ProcessMultiFactorView(LoginRequiredMixin, View):
 
 
 @method_decorator([never_cache, csrf_exempt], name='dispatch')
-class LogoutProcessView(LoginRequiredMixin, IdPHandlerViewMixin, View):
+class LogoutProcessView(CustomLoginRequiredMixin, IdPHandlerViewMixin, View):
     """ View which processes the actual SAML Single Logout request
         The login_required decorator ensures the user authenticates first on the IdP using 'normal' way.
     """

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -105,3 +105,7 @@ The default value for the fields ``processor`` and ``attribute_mapping`` can be 
 
     SAML_IDP_SP_FIELD_DEFAULT_PROCESSOR = 'djangosaml2idp.processors.BaseProcessor'
     SAML_IDP_SP_FIELD_DEFAULT_ATTRIBUTE_MAPPING = {"email": "email", "first_name": "first_name", "last_name": "last_name", "is_staff": "is_staff", "is_superuser": "is_superuser"}
+
+The djangosaml2idp views are composed with the Django [LoginRequiredMixin](https://docs.djangoproject.com/en/3.1/topics/auth/default/#the-loginrequired-mixin). In case there is a need to customize the *login_url* member for this set of views, it can be done through :
+
+    SAML_IDP_LOGIN_URL = '/custom/login/for/saml/idp/'


### PR DESCRIPTION
Add a new setting `SAML_IDP_LOGIN_URL` allowing to specifiy what would be the redirection target of the [LoginRequiredMixin](https://docs.djangoproject.com/en/3.1/topics/auth/default/#the-loginrequired-mixin) in case a user is not logged-in.