### PR TITLE
Fix temp folder location on Windows

### DIFF
--- a/djangosaml2idp/models.py
+++ b/djangosaml2idp/models.py
@@ -207,7 +207,8 @@ class ServiceProvider(models.Model):
         if refreshed_metadata:
             self.save()
 
-        path = '/tmp/djangosaml2idp'
+        # Get temp folder in a portable way (taken from https://stackoverflow.com/a/66528016)
+        path = ((os.getenv("TEMP") + '\\') if os.name=="nt" else "/tmp/") + 'djangosaml2idp'
         if not os.path.exists(path):
             try:
                 os.mkdir(path)


### PR DESCRIPTION
The temp folder used on `models.py` is hard-coded to `"/tmp"`.

This works fine in Linux as well as on Mac, but it breaks on Windows.

This pull request changes the hard-coded `"/tmp"` folder to a portable alternative, which allows djangosaml2idp to be used on Windows hosts.