### PR TITLE
Fix error when writting XML metadata with utf-8 characters

### DIFF
--- a/djangosaml2idp/models.py
+++ b/djangosaml2idp/models.py
@@ -219,7 +219,7 @@ class ServiceProvider(models.Model):
         # Rewrite the file if it did not exist yet, or if the SP config was updated after having written the file previously.
         if not os.path.exists(filename) or refreshed_metadata or (self.dt_updated and self.dt_updated.replace(tzinfo=pytz.utc) > datetime.datetime.fromtimestamp(os.path.getmtime(filename)).replace(tzinfo=pytz.utc)):
             try:
-                with open(filename, 'w') as f:
+                with open(filename, 'w', encoding='utf-8') as f:
                     f.write(self.local_metadata)
             except Exception as e:
                 logger.error(f'Could not write metadata to file {filename}: {e}')


### PR DESCRIPTION
If SP metadata contains utf-8 characters, for example letters with diacriticals, the generation of the corresponding XML file on the filesystem, fails with an error, resulting in interrupted SAML flow and, thus, blocking authentication (at least in the relatively dated systems I'm forced to use). Properly formatted Metadata XML SHOULD be utf-8, so, adding the encoding parameter to the open statement, fixes the problem.